### PR TITLE
Added tests for the reboot worker.

### DIFF
--- a/juju/paths/paths.go
+++ b/juju/paths/paths.go
@@ -2,6 +2,7 @@ package paths
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/juju/juju/version"
 )
@@ -63,6 +64,16 @@ func LogDir(series string) (string, error) {
 // store tools, charms, locks, etc
 func DataDir(series string) (string, error) {
 	return osVal(series, dataDir)
+}
+
+// LockDir returns the absolute path to the locks directory for
+// a particula series
+func LockDir(series string) (string, error) {
+	dataDir, err := DataDir(series)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dataDir, "locks"), nil
 }
 
 // JujuRun returns the absolute path to the juju-run binary for

--- a/utils/rebootstate/reboot.go
+++ b/utils/rebootstate/reboot.go
@@ -1,0 +1,55 @@
+package rebootstate
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils/uptime"
+
+	"github.com/juju/juju/agent"
+)
+
+var RebootStateFile = filepath.Join(agent.DefaultDataDir, "reboot-state.txt")
+
+// for testing
+var UptimeFunc = uptime.Uptime
+
+func New() error {
+	if _, err := os.Stat(RebootStateFile); err == nil {
+		return errors.Errorf("state file %s already exists", RebootStateFile)
+	}
+	uptime, err := UptimeFunc()
+	if err != nil {
+		return err
+	}
+
+	contents := []byte(strconv.FormatInt(uptime, 10))
+	err = ioutil.WriteFile(RebootStateFile, contents, 400)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func Remove() error {
+	if _, err := os.Stat(RebootStateFile); err == nil {
+		err = os.Remove(RebootStateFile)
+		return err
+	}
+	return nil
+}
+
+func Read() (int64, error) {
+	contents, err := ioutil.ReadFile(RebootStateFile)
+	if err != nil {
+		return 0, err
+	}
+	uptime, err := strconv.ParseInt(string(contents), 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return uptime, nil
+}

--- a/utils/rebootstate/reboot.go
+++ b/utils/rebootstate/reboot.go
@@ -4,30 +4,19 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils/uptime"
 
 	"github.com/juju/juju/agent"
 )
 
 var RebootStateFile = filepath.Join(agent.DefaultDataDir, "reboot-state.txt")
 
-// for testing
-var UptimeFunc = uptime.Uptime
-
 func New() error {
-	if _, err := os.Stat(RebootStateFile); err == nil {
+	if IsPresent() {
 		return errors.Errorf("state file %s already exists", RebootStateFile)
 	}
-	uptime, err := UptimeFunc()
-	if err != nil {
-		return err
-	}
-
-	contents := []byte(strconv.FormatInt(uptime, 10))
-	err = ioutil.WriteFile(RebootStateFile, contents, 400)
+	err := ioutil.WriteFile(RebootStateFile, []byte(""), 400)
 	if err != nil {
 		return err
 	}
@@ -42,14 +31,9 @@ func Remove() error {
 	return nil
 }
 
-func Read() (int64, error) {
-	contents, err := ioutil.ReadFile(RebootStateFile)
-	if err != nil {
-		return 0, err
+func IsPresent() bool {
+	if _, err := os.Stat(RebootStateFile); err != nil {
+		return false
 	}
-	uptime, err := strconv.ParseInt(string(contents), 10, 64)
-	if err != nil {
-		return 0, err
-	}
-	return uptime, nil
+	return true
 }

--- a/utils/rebootstate/reboot_test.go
+++ b/utils/rebootstate/reboot_test.go
@@ -1,0 +1,73 @@
+package rebootstate_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/utils/rebootstate"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}
+
+type rebootstateSuite struct {
+	jujutesting.IsolationSuite
+}
+
+var _ = gc.Suite(&rebootstateSuite{})
+
+func (s *rebootstateSuite) SetUpTest(c *gc.C) {
+	dataDir := c.MkDir()
+	s.PatchValue(&rebootstate.RebootStateFile, filepath.Join(dataDir, "reboot-state.txt"))
+	s.IsolationSuite.SetUpTest(c)
+}
+
+func (s *rebootstateSuite) TestNewState(c *gc.C) {
+	s.PatchValue(&rebootstate.UptimeFunc, func() (int64, error) { return int64(2), nil })
+	err := rebootstate.New()
+	c.Assert(err, gc.IsNil)
+	contents, err := ioutil.ReadFile(rebootstate.RebootStateFile)
+	c.Assert(err, gc.IsNil)
+	c.Assert(string(contents), gc.Equals, "2")
+}
+
+func (s *rebootstateSuite) TestMultipleNewState(c *gc.C) {
+	s.PatchValue(&rebootstate.UptimeFunc, func() (int64, error) { return int64(2), nil })
+	err := rebootstate.New()
+	c.Assert(err, gc.IsNil)
+	err = rebootstate.New()
+	c.Assert(err, gc.ErrorMatches, "state file (.*) already exists")
+}
+
+func (s *rebootstateSuite) TestReadState(c *gc.C) {
+	s.PatchValue(&rebootstate.UptimeFunc, func() (int64, error) { return int64(2), nil })
+	expectUtime, _ := rebootstate.UptimeFunc()
+	err := rebootstate.New()
+	c.Assert(err, gc.IsNil)
+	uptime, err := rebootstate.Read()
+	c.Assert(err, gc.IsNil)
+	c.Assert(uptime, gc.Equals, expectUtime)
+}
+
+func (s *rebootstateSuite) fileExists(path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		return false
+	}
+	return true
+}
+
+func (s *rebootstateSuite) TestRemoveState(c *gc.C) {
+	s.PatchValue(&rebootstate.UptimeFunc, func() (int64, error) { return int64(2), nil })
+	err := rebootstate.New()
+	c.Assert(err, gc.IsNil)
+	err = rebootstate.Remove()
+	c.Assert(err, gc.IsNil)
+	c.Assert(s.fileExists(rebootstate.RebootStateFile), jc.IsFalse)
+}

--- a/utils/rebootstate/reboot_test.go
+++ b/utils/rebootstate/reboot_test.go
@@ -1,7 +1,6 @@
 package rebootstate_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,42 +28,34 @@ func (s *rebootstateSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 }
 
+func (s *rebootstateSuite) fileExists(f string) bool {
+	if _, err := os.Stat(f); err != nil {
+		return false
+	}
+	return true
+}
+
 func (s *rebootstateSuite) TestNewState(c *gc.C) {
-	s.PatchValue(&rebootstate.UptimeFunc, func() (int64, error) { return int64(2), nil })
 	err := rebootstate.New()
 	c.Assert(err, gc.IsNil)
-	contents, err := ioutil.ReadFile(rebootstate.RebootStateFile)
-	c.Assert(err, gc.IsNil)
-	c.Assert(string(contents), gc.Equals, "2")
+	c.Assert(s.fileExists(rebootstate.RebootStateFile), jc.IsTrue)
 }
 
 func (s *rebootstateSuite) TestMultipleNewState(c *gc.C) {
-	s.PatchValue(&rebootstate.UptimeFunc, func() (int64, error) { return int64(2), nil })
 	err := rebootstate.New()
 	c.Assert(err, gc.IsNil)
 	err = rebootstate.New()
 	c.Assert(err, gc.ErrorMatches, "state file (.*) already exists")
 }
 
-func (s *rebootstateSuite) TestReadState(c *gc.C) {
-	s.PatchValue(&rebootstate.UptimeFunc, func() (int64, error) { return int64(2), nil })
-	expectUtime, _ := rebootstate.UptimeFunc()
+func (s *rebootstateSuite) TestIsPresent(c *gc.C) {
 	err := rebootstate.New()
 	c.Assert(err, gc.IsNil)
-	uptime, err := rebootstate.Read()
-	c.Assert(err, gc.IsNil)
-	c.Assert(uptime, gc.Equals, expectUtime)
-}
-
-func (s *rebootstateSuite) fileExists(path string) bool {
-	if _, err := os.Stat(path); err != nil {
-		return false
-	}
-	return true
+	exists := rebootstate.IsPresent()
+	c.Assert(exists, jc.IsTrue)
 }
 
 func (s *rebootstateSuite) TestRemoveState(c *gc.C) {
-	s.PatchValue(&rebootstate.UptimeFunc, func() (int64, error) { return int64(2), nil })
 	err := rebootstate.New()
 	c.Assert(err, gc.IsNil)
 	err = rebootstate.Remove()

--- a/worker/environ.go
+++ b/worker/environ.go
@@ -19,6 +19,7 @@ import (
 )
 
 var ErrTerminateAgent = errors.New("agent should be terminated")
+var ErrRebootMachine = errors.New("machine needs to reboot")
 
 var loadedInvalid = func() {}
 

--- a/worker/environ.go
+++ b/worker/environ.go
@@ -20,6 +20,7 @@ import (
 
 var ErrTerminateAgent = errors.New("agent should be terminated")
 var ErrRebootMachine = errors.New("machine needs to reboot")
+var ErrShutdownMachine = errors.New("machine needs to shutdown")
 
 var loadedInvalid = func() {}
 

--- a/worker/reboot/export_test.go
+++ b/worker/reboot/export_test.go
@@ -1,0 +1,15 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package reboot
+
+import "github.com/juju/juju/api/reboot"
+
+func (r *Reboot) CheckForRebootState() error {
+	return r.checkForRebootState()
+}
+
+func NewRebootStruct(st *reboot.State) Reboot {
+	return Reboot{st: st}
+}

--- a/worker/reboot/reboot.go
+++ b/worker/reboot/reboot.go
@@ -1,0 +1,69 @@
+package reboot
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names"
+	"launchpad.net/tomb"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api/reboot"
+	"github.com/juju/juju/api/watcher"
+	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/worker"
+)
+
+var logger = loggo.GetLogger("juju.worker.reboot")
+
+var _ worker.NotifyWatchHandler = (*Reboot)(nil)
+
+// The reboot worker listens for changes to the reboot flag and
+// exists with worker.ErrRebootMachine if the machine should shutdown
+// or reboot. This will be picked up by the machine agent as a fatal error
+// and will do the right thing (reboot or shutdown)
+type Reboot struct {
+	tomb tomb.Tomb
+	st   *reboot.State
+	tag  names.MachineTag
+}
+
+func NewReboot(st *reboot.State, agentConfig agent.Config) (worker.Worker, error) {
+	tag, ok := agentConfig.Tag().(names.MachineTag)
+	if !ok {
+		return nil, errors.Errorf("Expected names.MachineTag, got %T", agentConfig.Tag())
+	}
+	r := &Reboot{
+		st:  st,
+		tag: tag,
+	}
+	return worker.NewNotifyWorker(r), nil
+}
+
+func (r *Reboot) SetUp() (watcher.NotifyWatcher, error) {
+	logger.Debugf("Reboot worker setup")
+	watcher, err := r.st.WatchForRebootEvent()
+	if err != nil {
+		return nil, err
+	}
+	return watcher, nil
+}
+
+func (r *Reboot) Handle() error {
+	rAction, err := r.st.GetRebootAction()
+	if err != nil {
+		return err
+	}
+	logger.Debugf("Reboot worker got action: %v", rAction)
+	switch rAction {
+	case params.ShouldReboot:
+		return worker.ErrRebootMachine
+	case params.ShouldShutdown:
+		return worker.ErrRebootMachine
+	}
+	return nil
+}
+
+func (r *Reboot) TearDown() error {
+	// nothing to teardown.
+	return nil
+}

--- a/worker/reboot/reboot.go
+++ b/worker/reboot/reboot.go
@@ -25,9 +25,10 @@ const RebootMessage = "preparing for reboot"
 var _ worker.NotifyWatchHandler = (*Reboot)(nil)
 
 // The reboot worker listens for changes to the reboot flag and
-// exists with worker.ErrRebootMachine if the machine should shutdown
-// or reboot. This will be picked up by the machine agent as a fatal error
-// and will do the right thing (reboot or shutdown)
+// exists with worker.ErrRebootMachine if the machine should reboot or
+// with worker.ErrShutdownMachine if it should shutdoen. This will be picked
+// up by the machine agent as a fatal error and will do the
+// right thing (reboot or shutdown)
 type Reboot struct {
 	tomb tomb.Tomb
 	st   *reboot.State

--- a/worker/reboot/reboot.go
+++ b/worker/reboot/reboot.go
@@ -1,19 +1,29 @@
 package reboot
 
 import (
+	"os"
+
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
+	"github.com/juju/utils/fslock"
+	"github.com/juju/utils/uptime"
 	"launchpad.net/tomb"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/api/reboot"
 	"github.com/juju/juju/api/watcher"
 	"github.com/juju/juju/apiserver/params"
+	"github.com/juju/juju/juju/paths"
+	"github.com/juju/juju/utils/rebootstate"
+	"github.com/juju/juju/version"
 	"github.com/juju/juju/worker"
 )
 
 var logger = loggo.GetLogger("juju.worker.reboot")
+var LockDir = paths.MustSucceed(paths.LockDir(version.Current.Series))
+
+const RebootMessage = "preparing for reboot"
 
 var _ worker.NotifyWatchHandler = (*Reboot)(nil)
 
@@ -39,8 +49,75 @@ func NewReboot(st *reboot.State, agentConfig agent.Config) (worker.Worker, error
 	return worker.NewNotifyWorker(r), nil
 }
 
+func (r *Reboot) breakHookLock() error {
+	lock, err := fslock.NewLock(LockDir, "uniter-hook-execution")
+	if err != nil {
+		return err
+	}
+	if lock.Message() != RebootMessage {
+		// Not a lock held by the machine agent in order to reboot
+		return nil
+	}
+	err = lock.BreakLock()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *Reboot) checkForRebootState() error {
+	utime, err := rebootstate.Read()
+	if err != nil {
+		if _, ok := err.(*os.PathError); ok {
+			// No RebootStateFile was found.
+			return nil
+		}
+		return err
+	}
+
+	currentUptime, err := uptime.Uptime()
+	if err != nil {
+		return err
+	}
+	if utime < currentUptime {
+		// Uptime in the state file is lower then current uptime.
+		// This is normal if we set the file, but have not yet managed to do a reboot
+		// At this point however, the reboot flag in the state machine
+		// should be set if we still have to reboot.
+		rAction, err := r.st.GetRebootAction()
+		if err != nil {
+			return err
+		}
+		if rAction == params.ShouldDoNothing {
+			logger.Infof("Clearing stale reboot state file")
+			err = rebootstate.Remove()
+			return err
+		}
+		// We still have to reboot.
+		return nil
+	}
+
+	// Clear reboot flag
+	err = r.st.ClearReboot()
+	if err != nil {
+		logger.Errorf("Failed to clear reboot flag: %v", err)
+		return err
+	}
+	// Remove reboot state file
+	err = rebootstate.Remove()
+	if err != nil {
+		return err
+	}
+	// Break the hook lock if held
+	return r.breakHookLock()
+}
+
 func (r *Reboot) SetUp() (watcher.NotifyWatcher, error) {
 	logger.Debugf("Reboot worker setup")
+	err := r.checkForRebootState()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	watcher, err := r.st.WatchForRebootEvent()
 	if err != nil {
 		return nil, err

--- a/worker/reboot/reboot.go
+++ b/worker/reboot/reboot.go
@@ -7,7 +7,6 @@ import (
 	"github.com/juju/loggo"
 	"github.com/juju/names"
 	"github.com/juju/utils/fslock"
-	"github.com/juju/utils/uptime"
 	"launchpad.net/tomb"
 
 	"github.com/juju/juju/agent"

--- a/worker/reboot/reboot.go
+++ b/worker/reboot/reboot.go
@@ -58,7 +58,7 @@ func (r *Reboot) Handle() error {
 	case params.ShouldReboot:
 		return worker.ErrRebootMachine
 	case params.ShouldShutdown:
-		return worker.ErrRebootMachine
+		return worker.ErrShutdownMachine
 	}
 	return nil
 }

--- a/worker/reboot/reboot.go
+++ b/worker/reboot/reboot.go
@@ -1,8 +1,6 @@
 package reboot
 
 import (
-	"os"
-
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	"github.com/juju/names"
@@ -65,13 +63,8 @@ func (r *Reboot) breakHookLock() error {
 }
 
 func (r *Reboot) checkForRebootState() error {
-	_, err := rebootstate.Read()
-	if err != nil {
-		if _, ok := err.(*os.PathError); ok {
-			// No RebootStateFile was found.
-			return nil
-		}
-		return err
+	if !rebootstate.IsPresent() {
+		return nil
 	}
 
 	// Check if reboot flag is set.

--- a/worker/reboot/reboot_test.go
+++ b/worker/reboot/reboot_test.go
@@ -1,0 +1,207 @@
+// Copyright 2014 Canonical Ltd.
+// Copyright 2014 Cloudbase Solutions SRL
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package reboot_test
+
+import (
+	"fmt"
+	"path/filepath"
+	stdtesting "testing"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api"
+	apireboot "github.com/juju/juju/api/reboot"
+	"github.com/juju/juju/apiserver/params"
+	jujutesting "github.com/juju/juju/juju/testing"
+	coretesting "github.com/juju/juju/testing"
+	"github.com/juju/juju/utils/rebootstate"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/worker"
+	"github.com/juju/juju/worker/reboot"
+)
+
+func TestAll(t *stdtesting.T) {
+	coretesting.MgoTestPackage(t)
+}
+
+type RebootSuite struct {
+	jujutesting.JujuConnSuite
+
+	stateMachine	*state.Machine
+	apiState		*api.State
+	rebootState		*apireboot.State
+}
+
+var _ = gc.Suite(&RebootSuite{})
+
+func (s *RebootSuite) SetUpSuite(c *gc.C) {
+	s.JujuConnSuite.SetUpSuite(c)
+}
+
+func (s *RebootSuite) SetUpTest(c *gc.C) {
+	var err error
+	s.PatchValue(&reboot.LockDir, c.MkDir())
+	s.PatchValue(&rebootstate.RebootStateFile, 
+		filepath.Join(c.MkDir(), "reboot-state.txt"))
+
+	s.JujuConnSuite.SetUpTest(c)
+	s.apiState, s.stateMachine = s.OpenAPIAsNewMachine(c)
+	s.rebootState, err = s.apiState.Reboot()
+	c.Assert(s.rebootState, gc.NotNil)
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *RebootSuite) TearDownTest(c *gc.C) {
+	s.JujuConnSuite.TearDownTest(c)
+}
+
+func (s *RebootSuite) TearDownSuite(c *gc.C) {
+	s.JujuConnSuite.TearDownSuite(c)
+}
+
+
+func (s *RebootSuite) TestCheckForRebootState(c *gc.C) {
+	rebootWorker := reboot.NewRebootStruct(s.rebootState)
+
+	// test immediate return when no state files are found
+	err := rebootWorker.CheckForRebootState()
+	c.Assert(err, gc.IsNil)
+
+	// test that an error in a GetRebootAction call triggers abort 
+	// while leaving the state file intact
+	err = rebootstate.New()
+	c.Assert(err, gc.IsNil)
+	apireboot.PatchFacadeCall(s, s.rebootState, func(name string, p, resp interface{}) error {
+			return fmt.Errorf("GetRebootAction call error!")
+		})
+
+	err = rebootWorker.CheckForRebootState()
+	c.Assert(err, gc.ErrorMatches, "GetRebootAction call error!")
+	c.Assert(rebootstate.IsPresent(), jc.IsTrue)
+
+
+	// test for succesful GetRebootAction call with returned ShouldDoNothing
+	// flag and that reboot state file is properly cleared afterwards
+	apireboot.PatchFacadeCall(s, s.rebootState, func(name string, p, resp interface{}) error {
+			if resp, ok := resp.(*params.RebootActionResults); ok {
+				resp.Results = []params.RebootActionResult {
+					{ Result: params.ShouldDoNothing },
+				}
+			}
+			return nil
+		})
+
+	err = rebootWorker.CheckForRebootState()
+	c.Assert(err, gc.IsNil)
+	c.Assert(rebootstate.IsPresent(), jc.IsFalse)
+
+	// test for succesful call of GetRebootAction call but failed ClearReboot
+	// and that state file is left intact
+	err = rebootstate.New()
+	c.Assert(err, gc.IsNil)
+	apireboot.PatchFacadeCall(s, s.rebootState, func(name string, p, resp interface{}) error {
+			if name == "GetRebootAction" {
+				if resp, ok := resp.(*params.RebootActionResults); ok {
+					resp.Results = []params.RebootActionResult {
+						{ Result: params.ShouldReboot },
+					}	
+				}
+			} else {
+				if resp, ok := resp.(*params.ErrorResults); ok {
+					resp.Results = []params.ErrorResult {
+						{ Error: &params.Error{ Message: "ClearReboot call error!" } },
+					}
+				}
+			}
+			return nil
+		})
+
+	err = rebootWorker.CheckForRebootState()
+	c.Assert(err, gc.ErrorMatches, "ClearReboot call error!")
+	c.Assert(rebootstate.IsPresent(), jc.IsTrue)
+
+	// test for succesful calls of GetRebootAction and ClearReboot
+	// assuring that the state files were cleared
+	apireboot.PatchFacadeCall(s, s.rebootState, func(name string, p, resp interface{}) error {
+			if name == "GetRebootAction" {
+				if resp, ok := resp.(*params.RebootActionResults); ok {
+					resp.Results = []params.RebootActionResult {
+						{ Result: params.ShouldReboot },
+					}
+				}
+			} else {
+				if resp, ok := resp.(*params.ErrorResults); ok {
+					resp.Results = []params.ErrorResult {
+						{ Error: nil },
+					}
+				}
+			}
+			return nil
+		})
+
+	err = rebootWorker.CheckForRebootState()
+	c.Assert(err, gc.IsNil)
+	c.Assert(rebootstate.IsPresent(), jc.IsFalse)
+}
+
+func (s *RebootSuite)TestHandleFacadeCallError(c *gc.C) {
+	rebootWorker := reboot.NewRebootStruct(s.rebootState)
+
+	apireboot.PatchFacadeCall(s, s.rebootState, func(name string, p, resp interface{}) error {
+			return fmt.Errorf("GetRebootAction call error!")
+		})
+
+	err := rebootWorker.Handle()
+	c.Assert(err, gc.ErrorMatches, "GetRebootAction call error!")
+}
+
+func (s *RebootSuite) TestHandleShouldDoNothing(c *gc.C) {
+	rebootWorker := reboot.NewRebootStruct(s.rebootState)
+
+	apireboot.PatchFacadeCall(s, s.rebootState, func(name string, p, resp interface{}) error {
+			if resp, ok := resp.(*params.RebootActionResults); ok {
+				resp.Results = []params.RebootActionResult {
+					{ Result: params.ShouldDoNothing },
+				}
+			}
+			return nil
+		})
+
+	err := rebootWorker.Handle()
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *RebootSuite) TestHandleShouldShutdown(c *gc.C) {
+	rebootWorker := reboot.NewRebootStruct(s.rebootState)
+
+	apireboot.PatchFacadeCall(s, s.rebootState, func(name string, p, resp interface{}) error {
+			if resp, ok := resp.(*params.RebootActionResults); ok {
+				resp.Results = []params.RebootActionResult {
+					{ Result: params.ShouldShutdown },
+				}
+			}
+			return nil
+		})
+
+	err := rebootWorker.Handle()
+	c.Assert(err, gc.Equals, worker.ErrShutdownMachine)
+}
+
+func (s *RebootSuite) TestHandleShouldReboot(c *gc.C) {
+	rebootWorker := reboot.NewRebootStruct(s.rebootState)
+
+	apireboot.PatchFacadeCall(s, s.rebootState, func(name string, p, resp interface{}) error {
+			if resp, ok := resp.(*params.RebootActionResults); ok {
+				resp.Results = []params.RebootActionResult {
+					{ Result: params.ShouldReboot },
+				}
+			}
+			return nil
+		})
+
+	err := rebootWorker.Handle()
+	c.Assert(err, gc.Equals, worker.ErrRebootMachine)
+}


### PR DESCRIPTION
This pull specifically requires that "/api/reboot/export_test.go" from [this](https://github.com/juju/juju/pull/744) pull be renamed in order to access the PatchFacadeCall function found there.